### PR TITLE
Fix for negative index in List.apply.

### DIFF
--- a/src/collection/List.scala
+++ b/src/collection/List.scala
@@ -75,6 +75,7 @@ abstract sealed class List[+A] {
    */
   def apply(n: Int): A =
     if (isEmpty) fail("Index out of the bounds.")
+    else if (n < 0) fail("Index (< 0) out of bounds.")
     else if (n == 0) head
     else tail(n - 1)
 

--- a/src/collection/List.scala
+++ b/src/collection/List.scala
@@ -74,7 +74,7 @@ abstract sealed class List[+A] {
    * Space - O(n)
    */
   def apply(n: Int): A =
-    if (isEmpty) fail("Index out of the bounds.")
+    if (isEmpty) fail("Index out of bounds.")
     else if (n < 0) fail("Index (< 0) out of bounds.")
     else if (n == 0) head
     else tail(n - 1)


### PR DESCRIPTION
Looking up the `ith` element of a List will currently give a correct but unhelpful failure message for `i < 0`. Make the failure message more helpful.